### PR TITLE
Separate the parsing of the yaml file from the core logic

### DIFF
--- a/examples/1.yaml
+++ b/examples/1.yaml
@@ -3,7 +3,6 @@ apiVersion: generic-webhook/v1alpha1
 kind: GenericWebhookConfig
 webhooks:
   - name: cmd-patch
-    port: 8888
     path: cmd-patch
     actions:
       # Removes the command if it performs a "sleep"
@@ -18,7 +17,7 @@ webhooks:
               const: sleep
         patch:
           op: remove
-          path: command
+          path: .command
         # No need to specify this, since we always
         # accept by default, unless there's some error
         accept: true

--- a/generic_k8s_webhook/config_parser.py
+++ b/generic_k8s_webhook/config_parser.py
@@ -1,7 +1,16 @@
+import abc
 import copy
+import inspect
+import re
+import sys
+
 import generic_k8s_webhook.utils as utils
 import generic_k8s_webhook.operators as operators
+from generic_k8s_webhook.webhook import Webhook, Action
 
+
+class ParsingException(Exception):
+    pass
 
 class Manifest:
     APIGROUP = "generic-webhook"
@@ -10,7 +19,7 @@ class Manifest:
     def __init__(self, raw_config: dict) -> None:
         # We do a deep copy of raw_config since we remove its fields as we read them
         raw_config = copy.deepcopy(raw_config)
-        
+
         raw_api_version = utils.must_pop(raw_config, "apiVersion", "apiVersion not defined")
 
         self.apigroup = raw_api_version.split("/")[0]
@@ -26,36 +35,219 @@ class Manifest:
         raw_list_webhook_config = utils.must_pop(raw_config, "webhooks", "webhooks not defined")
         if not isinstance(raw_list_webhook_config, list):
             raise ValueError(f"The webhooks must be a list but it's a {type(raw_list_webhook_config)}")
-        self.list_webhook_config = [WebhookConfig(raw_webhook_config) for raw_webhook_config in raw_list_webhook_config]
+        self.list_webhook_config = [WebhookParser.parse(raw_webhook_config, f"webhooks.{i}")
+                                    for i, raw_webhook_config in enumerate(raw_list_webhook_config)]
 
         if len(raw_config) > 0:
             ValueError(f"Invalid fields at the manifest level: {raw_config}")
 
 
-class WebhookConfig:
-    def __init__(self, raw_config: dict) -> None:
-        self.name = utils.must_pop(raw_config, "name", "The webhook must have a name")
-        self.port = utils.must_pop(raw_config, "port", f"The webhook {self.name} must have a port")
-        self.path = utils.must_pop(raw_config, "path", f"The webhook {self.name} must have a path")
+class WebhookParser:
+    @classmethod
+    def parse(clx, raw_config: dict, path_wh: str) -> Webhook:
+        name = utils.must_pop(raw_config, "name", f"The webhook {path_wh} must have a name")
+        path = utils.must_pop(raw_config, "path", f"The webhook {path_wh} must have a path")
 
-        raw_list_actions = utils.must_pop(raw_config, "actions", f"The webhook {self.name} must have a actions defined")
-        self.actions = [Action(raw_action) for raw_action in raw_list_actions]
+        raw_list_action_configs = utils.must_pop(raw_config, "actions",
+                                                 f"The webhook {name} must have a actions defined")
+        list_actions = [ActionParser.parse(raw_action, f"{path_wh}.actions.{i}")
+                        for i, raw_action in enumerate(raw_list_action_configs)]
 
         if len(raw_config) > 0:
-            ValueError(f"Invalid fields in webhook {self.name}: {raw_config}")
+            ValueError(f"Invalid fields in webhook {path_wh}: {raw_config}")
+
+        return Webhook(name, path, list_actions)
 
 
-class Action:
-    def __init__(self, raw_config: dict) -> None:
-        self.for_each = raw_config.pop("forEach", None)
+class ActionParser:
+    @classmethod
+    def parse(cls, raw_config: dict, path_action: str) -> Action:
+        # TODO Add support for the "forEach" keyword
+        #
+        # raw_foreach = raw_config.pop("forEach", None)
+        # if raw_foreach is not None:
+        #     self.foreach  = operators.parse_operator(raw_foreach, "forEach")
+        # else:
+        #     self.foreach = None
 
         # If the condition is not defined, we default to True
         raw_condition = raw_config.pop("condition", {"const": True})
-        self.condition = operators.parse_operator(raw_condition, "condition")
+        condition = parse_operator(raw_condition, f"{path_action}.condition")
 
-        self.patch = raw_config.pop("patch", None)
+        patch = raw_config.pop("patch", None)
         # By default, we always accept the payload
-        self.accept = raw_config.pop("accept", True)
+        accept = raw_config.pop("accept", True)
 
         if len(raw_config) > 0:
-            ValueError(f"Invalid fields in an action: {raw_config}")
+            ValueError(f"Invalid fields in action {path_action}: {raw_config}")
+
+        return Action(condition, patch, accept)
+
+
+class OperatorParser(abc.ABC):
+    @abc.abstractclassmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.Operator:
+        pass
+
+
+class BinaryOpParser(OperatorParser):
+    OPERATOR_CLS = operators.BinaryOp
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.BinaryOp:
+        if isinstance(op_inputs, list):
+            args = ListParser.parse(op_inputs, path_op)
+        elif isinstance(op_inputs, dict):
+            args = parse_operator(op_inputs, path_op)
+        else:
+            raise ValueError(f"Expected dict or list as input, but got {op_inputs}")
+
+        try:
+            return cls.OPERATOR_CLS(args)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class AndParser(BinaryOpParser):
+    NAME = "and"
+    OPERATOR_CLS = operators.And
+
+
+class OrParser(BinaryOpParser):
+    NAME = "or"
+    OPERATOR_CLS = operators.Or
+
+
+class EqualParser(BinaryOpParser):
+    NAME = "equal"
+    OPERATOR_CLS = operators.Equal
+
+
+class SumParser(BinaryOpParser):
+    NAME = "sum"
+    OPERATOR_CLS = operators.Sum
+
+
+class UnaryOpParser(OperatorParser):
+    OPERATOR_CLS = operators.UnaryOp
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.UnaryOp:
+        arg = parse_operator(op_inputs, path_op)
+        try:
+            return cls.OPERATOR_CLS(arg)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class NotParser(UnaryOpParser):
+    NAME = "not"
+    OPERATOR_CLS = operators.Not
+
+class ListParser(OperatorParser):
+    NAME = "list"
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.List:
+        list_op = []
+        for i, op in enumerate(op_inputs):
+            parsed_op = parse_operator(op, f"{path_op}.{i}")
+            list_op.append(parsed_op)
+        try:
+            return operators.List(list_op)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class ForEachParser(OperatorParser):
+    NAME = "forEach"
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.ForEach:
+        raw_elements = utils.must_get(op_inputs, "elements", f"In {path_op}, required 'elements'")
+        elements = parse_operator(raw_elements, f"{path_op}.elements")
+
+        raw_op = utils.must_get(op_inputs, "op", f"In {path_op}, required 'op'")
+        op = parse_operator(raw_op, f"{path_op}.op")
+
+        try:
+            return operators.ForEach(elements, op)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class ContainParser(OperatorParser):
+    NAME = "contain"
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.Contain:
+        raw_elements = utils.must_get(op_inputs, "elements", f"In {path_op}, required 'elements'")
+        elements = parse_operator(raw_elements, f"{path_op}.elements")
+
+        raw_elem = utils.must_get(op_inputs, "value", f"In {path_op}, required 'value'")
+        elem = parse_operator(raw_elem, f"{path_op}.value")
+
+        try:
+            return operators.Contain(elements, elem)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class ConstParser(OperatorParser):
+    NAME = "const"
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.Const:
+        try:
+            return operators.Const(op_inputs)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+class GetValueParser(OperatorParser):
+    NAME = "getValue"
+
+    @classmethod
+    def parse(cls, op_inputs: dict | list, path_op: str) -> operators.GetValue:
+        if not isinstance(op_inputs, str):
+            raise ValueError(f"Expected to find str but got {op_inputs} in {path_op}")
+        # Split by '.', but not by '\.'
+        path = re.split(r"(?<!\\)\.", op_inputs)
+        # Convert the '\.' to '.'
+        path = [elem.replace("\\.", ".") for elem in path]
+
+        # Get the id of the context that it will use
+        if path[0] == "":
+            context_id = -1
+        elif path[0] == "$":
+            context_id = 0
+        else:
+            raise ValueError(f"Invalid {path[0]} in {path_op}")
+
+        try:
+            return operators.GetValue(path, context_id)
+        except TypeError as e:
+            raise ParsingException(f"Error when parsing {path_op}. {e}")
+
+
+# Magic dictionary that contains all the operators config defined in this file
+DICT_OPERATORS = {}
+for _, obj in inspect.getmembers(sys.modules[__name__]):
+    if (isinstance(obj, type) and
+        issubclass(obj, OperatorParser) and
+        hasattr(obj, "NAME")):
+            if obj.NAME in DICT_OPERATORS:
+                raise RuntimeError(f"Duplicated operator {obj.NAME}")
+            DICT_OPERATORS[obj.NAME] = obj
+
+
+def parse_operator(op_spec: dict, path_op: str="") -> operators.Operator:
+    if len(op_spec) != 1:
+        raise ValueError(f"Expected exactly one key under {path_op}")
+    op_name, op_spec = op_spec.popitem()
+    if op_name not in DICT_OPERATORS:
+        raise ValueError(f"The operator {op_name} from {path_op} is not defined")
+    op_class = DICT_OPERATORS[op_name]
+    op = op_class.parse(op_spec, f"{path_op}.{op_name}")
+
+    return op

--- a/generic_k8s_webhook/http_server.py
+++ b/generic_k8s_webhook/http_server.py
@@ -1,0 +1,10 @@
+import http.server
+import ssl
+
+
+# TODO Create a Handler that only serves on a single path. In the future, we'll extend that,
+# so the same app will implement different webhooks. Notice that the GenericWebhookConfig
+# yaml already supports that.
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    pass

--- a/generic_k8s_webhook/webhook.py
+++ b/generic_k8s_webhook/webhook.py
@@ -1,0 +1,41 @@
+import http.server
+import ssl
+import copy
+from generic_k8s_webhook.operators import Operator
+
+
+class Action:
+    def __init__(self, condition: Operator, patch: dict, accept: bool) -> None:
+        self.condition = condition
+        self.patch = patch
+        self.accept = accept
+
+    def check_condition(self, manifest: dict) -> bool:
+        return self.condition.get_value([manifest])
+
+    def get_patches(self, manifest: dict) -> list[dict]:
+        if not self.patch:
+            return None
+
+        # TODO This needs much better robustness and error handling
+        formatted_patch = copy.deepcopy(self.patch)
+        for key in ["path", "from"]:
+            if key in formatted_patch:
+                formatted_patch[key] = "/" + formatted_patch[key][1:]
+        return [formatted_patch]
+
+
+class Webhook:
+    def __init__(self, name: str, path: str, list_actions: list[Action]) -> None:
+        self.name = name
+        self.path = path
+        self.list_actions = list_actions
+
+    def process_manifest(self, manifest: dict) -> tuple[bool, list[dict]]:
+        for action in self.list_actions:
+            if action.check_condition(manifest):
+                patches = action.get_patches(manifest)
+                return action.accept, patches
+
+        # If no condition is met, we'll accept the manifest without any patch
+        return True, None

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -13,7 +13,7 @@ def get_yaml(path: str) -> dict:
     abs_path = os.path.join(SCRIPT_DIR, path)
     with open(abs_path, "r") as f:
         return yaml.safe_load(f)
-    
+
 
 def test_valid_config():
     raw_config = get_yaml("webhook_configs/config1.yaml")
@@ -22,13 +22,12 @@ def test_valid_config():
     assert config.apiversion == "v1alpha1"
     assert config.kind == raw_config["kind"]
     assert len(config.list_webhook_config) == 1
-    
+
     webhook = config.list_webhook_config[0]
     raw_webhook = raw_config["webhooks"][0]
     assert webhook.name == raw_webhook["name"]
-    assert webhook.port == raw_webhook["port"]
     assert webhook.path == raw_webhook["path"]
-    assert len(webhook.actions) == 1
+    assert len(webhook.list_actions) == 1
 
-    actions = webhook.actions[0]
-    assert actions.accept == True
+    action = webhook.list_actions[0]
+    assert action.accept == True

--- a/tests/opetators_test.py
+++ b/tests/opetators_test.py
@@ -3,7 +3,7 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
-import generic_k8s_webhook.operators as ops
+import generic_k8s_webhook.config_parser as cfg_parser
 
 
 @pytest.mark.parametrize(("op", "inputs", "expected_result"), [
@@ -78,7 +78,7 @@ import generic_k8s_webhook.operators as ops
     )
 ])
 def test_basic_operators(op, inputs, expected_result):
-    op = ops.parse_operator({op: inputs})
+    op = cfg_parser.parse_operator({op: inputs})
     result = op.get_value([])
     assert result == expected_result
 
@@ -114,7 +114,7 @@ def test_basic_operators(op, inputs, expected_result):
     ),
 ])
 def test_path(name, contexts, path, expected_result):
-    op = ops.parse_operator({"getValue": path})
+    op = cfg_parser.parse_operator({"getValue": path})
     result = op.get_value(contexts)
     assert result == expected_result
 
@@ -158,7 +158,7 @@ def test_path(name, contexts, path, expected_result):
     ),
 ])
 def test_foreach(name, contexts, inputs, expected_result):
-    op = ops.parse_operator({"forEach": inputs})
+    op = cfg_parser.parse_operator({"forEach": inputs})
     result = op.get_value(contexts)
     assert result == expected_result
 
@@ -198,6 +198,6 @@ def test_foreach(name, contexts, inputs, expected_result):
     ),
 ])
 def test_contain(name, contexts, inputs, expected_result):
-    op = ops.parse_operator({"contain": inputs})
+    op = cfg_parser.parse_operator({"contain": inputs})
     result = op.get_value(contexts)
     assert result == expected_result

--- a/tests/webhook_configs/config1.yaml
+++ b/tests/webhook_configs/config1.yaml
@@ -3,7 +3,6 @@ apiVersion: generic-webhook/v1alpha1
 kind: GenericWebhookConfig
 webhooks:
   - name: cmd-patch
-    port: 8888
     path: cmd-patch
     actions:
       - condition:


### PR DESCRIPTION
The Operator, Action or Webhook classes no longer depend on the structure of the yaml file manifest that we use to define them. Instead, equivalent parser classes consume the yaml, resolve default values, check that we have the required fields and then create the core classes (Operator, Action, Wehbook, etc.). This helps use decouple these core classes from the schema that the yaml file will follow.

Apart from that, this commit adds the following changes
- Remove support for the "forEach" keyword at the webhook level. In the future, we'll add it again
- The port will not be specified per webhook. Instead, the app will listen to a single port and will invoke the corresponding webhook depending on the url path.