### PR TITLE
Add CI job to execute the unittests

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,0 +1,28 @@
+name: Test PRs
+on:
+  pull_request:
+    types: [labeled] # So that only labelled PRs get run. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+# Explicitly grant the `secrets.GITHUB_TOKEN` no permissions.
+permissions: {}
+jobs:
+  execute-unittests:
+    name: Execute the unittests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Action
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install poetry
+        run: python3 -m pip install poetry
+
+      - name: Install Python libraries
+        run: poetry install
+
+      - name: Test
+        run: poetry run pytest tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,96 @@
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "packaging"
+version = "23.1"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pytest"
+version = "7.3.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "8aa9df84fd0a718f2fe697c43f5c97705f7d00762a83f93f681a1b59749c7462"
+
+[metadata.files]
+colorama = []
+exceptiongroup = []
+iniconfig = []
+packaging = []
+pluggy = []
+pytest = []
+pyyaml = []
+tomli = []

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -1,12 +1,8 @@
-import pytest
 import yaml
 import os
-import sys
+import generic_k8s_webhook.config_parser as config_parser
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(SCRIPT_DIR + "/..")
-
-import generic_k8s_webhook.config_parser as config_parser
 
 
 def get_yaml(path: str) -> dict:

--- a/tests/opetators_test.py
+++ b/tests/opetators_test.py
@@ -1,8 +1,4 @@
 import pytest
-import sys
-import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
-
 import generic_k8s_webhook.config_parser as cfg_parser
 
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -v


### PR DESCRIPTION
To have fully reproducible tests, we've commited the poetry.lock file to the repo. Without it, we could have different behaviour locally and in the CI due to different versions in the libraries that we consume.