### PR TITLE
Fix BinaryOp when we have an empty list of args

### DIFF
--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -4,14 +4,16 @@ set -e
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-if [ ! "$1" = "--check" ]
+if [ "$1" = "--check" ]
 then
-    NO_CHECK="true"
+    CHECK=true
+else
+    CHECK=false
 fi
 
 cd "$SCRIPTPATH/.."
-poetry run isort generic_k8s_webhook/ "${NO_CHECK:--c}"
-poetry run black generic_k8s_webhook/ "${NO_CHECK:---check}"
+poetry run isort generic_k8s_webhook/ $($CHECK && echo "-c")
+poetry run black generic_k8s_webhook/ $($CHECK && echo "--check")
 if [ -z "$NO_CHECK" ]
 then
     poetry run pylint generic_k8s_webhook/ -E

--- a/tests/opetators_test.py
+++ b/tests/opetators_test.py
@@ -20,6 +20,18 @@ import generic_k8s_webhook.config_parser as cfg_parser
         False
     ),
     (
+        "and",
+        [
+            {"const": False},
+        ],
+        False
+    ),
+    (
+        "and",
+        [],
+        True
+    ),
+    (
         "or",
         [
             {"const": False},
@@ -36,9 +48,26 @@ import generic_k8s_webhook.config_parser as cfg_parser
         True
     ),
     (
+        "or",
+        [
+            {"const": True},
+        ],
+        True
+    ),
+    (
+        "or",
+        [],
+        True
+    ),
+    (
         "not",
         {"const": True},
         False
+    ),
+    (
+        "equal",
+        [],
+        True
     ),
     (
         "equal",
@@ -71,6 +100,18 @@ import generic_k8s_webhook.config_parser as cfg_parser
             {"const": 4},
         ],
         9
+    ),
+    (
+        "sum",
+        [
+            {"const": 2},
+        ],
+        2
+    ),
+    (
+        "sum",
+        [],
+        0
     )
 ])
 def test_basic_operators(op, inputs, expected_result):


### PR DESCRIPTION
All the BinaryOp operations returned the neutral element when the list of args was empty. This bug was manifested in case of the OR operation, since we want to output True when the list of arguments is empty, but its neutral element is False.