### PR TITLE
Add black formatting and isort to the tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ isort = "^5.12.0"
 black = "^23.3.0"
 pylint = "^2.17.4"
 
+[tool.isort]
+line_length = 120
+
 [tool.black]
 line-length = 120
 

--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -12,8 +12,8 @@ else
 fi
 
 cd "$SCRIPTPATH/.."
-poetry run isort generic_k8s_webhook/ $($CHECK && echo "-c")
-poetry run black generic_k8s_webhook/ $($CHECK && echo "--check")
+poetry run isort generic_k8s_webhook/ tests/ $($CHECK && echo "-c")
+poetry run black generic_k8s_webhook/ tests/ $($CHECK && echo "--check")
 if $CHECK
 then
     poetry run pylint generic_k8s_webhook/ -E

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -1,5 +1,7 @@
-import yaml
 import os
+
+import yaml
+
 import generic_k8s_webhook.config_parser as config_parser
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/end2end_test.py
+++ b/tests/end2end_test.py
@@ -1,19 +1,14 @@
 import base64
-import copy
-import yaml
-import pytest
-from pathlib import Path
-from typing import Any
-import os
-import socket
-import threading
-import requests
 import json
-import time
-import subprocess
+import os
 import signal
+import subprocess
+import threading
 
-from http_server_test import load_test_case, get_free_port, wait_for_server_ready
+import pytest
+import requests
+import yaml
+from http_server_test import get_free_port, load_test_case, wait_for_server_ready
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 HTTP_SERVER_TEST_DATA_DIR = os.path.join(SCRIPT_DIR, "http_server_test_data")

--- a/tests/http_server_test.py
+++ b/tests/http_server_test.py
@@ -1,13 +1,13 @@
 import base64
-import yaml
-import pytest
+import json
 import os
 import threading
-import requests
-import json
 import time
 
-from test_utils import load_test_case, get_free_port, wait_for_server_ready
+import pytest
+import requests
+import yaml
+from test_utils import get_free_port, load_test_case, wait_for_server_ready
 
 from generic_k8s_webhook.http_server import Server
 

--- a/tests/opetators_test.py
+++ b/tests/opetators_test.py
@@ -1,239 +1,199 @@
 import pytest
+
 import generic_k8s_webhook.config_parser as cfg_parser
 
 
-@pytest.mark.parametrize(("op", "inputs", "expected_result"), [
-    (
-        "and",
-        [
-            {"const": True},
-            {"const": True},
-        ],
-        True
-    ),
-    (
-        "and",
-        [
-            {"const": True},
-            {"const": False},
-        ],
-        False
-    ),
-    (
-        "and",
-        [
-            {"const": False},
-        ],
-        False
-    ),
-    (
-        "and",
-        [],
-        True
-    ),
-    (
-        "or",
-        [
-            {"const": False},
-            {"const": False},
-        ],
-        False
-    ),
-    (
-        "or",
-        [
-            {"const": True},
-            {"const": False},
-        ],
-        True
-    ),
-    (
-        "or",
-        [
-            {"const": True},
-        ],
-        True
-    ),
-    (
-        "or",
-        [],
-        True
-    ),
-    (
-        "not",
-        {"const": True},
-        False
-    ),
-    (
-        "equal",
-        [],
-        True
-    ),
-    (
-        "equal",
-        [
-            {"const": 1},
-        ],
-        True
-    ),
-    (
-        "equal",
-        [
-            {"const": 2},
-            {"const": 3},
-        ],
-        False
-    ),
-    (
-        "equal",
-        [
-            {"const": 4},
-            {"const": 4},
-        ],
-        True
-    ),
-    (
-        "sum",
-        [
-            {"const": 2},
-            {"const": 3},
-            {"const": 4},
-        ],
-        9
-    ),
-    (
-        "sum",
-        [
-            {"const": 2},
-        ],
-        2
-    ),
-    (
-        "sum",
-        [],
-        0
-    )
-])
+@pytest.mark.parametrize(
+    ("op", "inputs", "expected_result"),
+    [
+        (
+            "and",
+            [
+                {"const": True},
+                {"const": True},
+            ],
+            True,
+        ),
+        (
+            "and",
+            [
+                {"const": True},
+                {"const": False},
+            ],
+            False,
+        ),
+        (
+            "and",
+            [
+                {"const": False},
+            ],
+            False,
+        ),
+        ("and", [], True),
+        (
+            "or",
+            [
+                {"const": False},
+                {"const": False},
+            ],
+            False,
+        ),
+        (
+            "or",
+            [
+                {"const": True},
+                {"const": False},
+            ],
+            True,
+        ),
+        (
+            "or",
+            [
+                {"const": True},
+            ],
+            True,
+        ),
+        ("or", [], True),
+        ("not", {"const": True}, False),
+        ("equal", [], True),
+        (
+            "equal",
+            [
+                {"const": 1},
+            ],
+            True,
+        ),
+        (
+            "equal",
+            [
+                {"const": 2},
+                {"const": 3},
+            ],
+            False,
+        ),
+        (
+            "equal",
+            [
+                {"const": 4},
+                {"const": 4},
+            ],
+            True,
+        ),
+        (
+            "sum",
+            [
+                {"const": 2},
+                {"const": 3},
+                {"const": 4},
+            ],
+            9,
+        ),
+        (
+            "sum",
+            [
+                {"const": 2},
+            ],
+            2,
+        ),
+        ("sum", [], 0),
+    ],
+)
 def test_basic_operators(op, inputs, expected_result):
     op = cfg_parser.parse_operator({op: inputs})
     result = op.get_value([])
     assert result == expected_result
 
 
-@pytest.mark.parametrize(("name", "contexts", "path", "expected_result"), [
-    (
-        "Retrieve value from last context",
-        [
-            {
-                "metadata": {"name": "foo"},
-                "spec": {}
-            },
-            {
-                "name": "bar"
-            },
-        ],
-        ".name",
-        "bar",
-    ),
-    (
-        "Retrieve value from first context",
-        [
-            {
-                "metadata": {"name": "foo"},
-                "spec": {}
-            },
-            {
-                "name": "bar"
-            },
-        ],
-        "$.metadata.name",
-        "foo",
-    ),
-])
+@pytest.mark.parametrize(
+    ("name", "contexts", "path", "expected_result"),
+    [
+        (
+            "Retrieve value from last context",
+            [
+                {"metadata": {"name": "foo"}, "spec": {}},
+                {"name": "bar"},
+            ],
+            ".name",
+            "bar",
+        ),
+        (
+            "Retrieve value from first context",
+            [
+                {"metadata": {"name": "foo"}, "spec": {}},
+                {"name": "bar"},
+            ],
+            "$.metadata.name",
+            "foo",
+        ),
+    ],
+)
 def test_path(name, contexts, path, expected_result):
     op = cfg_parser.parse_operator({"getValue": path})
     result = op.get_value(contexts)
     assert result == expected_result
 
 
-@pytest.mark.parametrize(("name", "contexts", "inputs", "expected_result"), [
-    (
-        "Iterate over a constant list of elements and sum 10 to each",
-        [],
-        {
-            "elements": {"const": [
-                1,
-                2,
-            ]},
-            "op": {
-                "sum": [
-                    {"const": 10},
-                    {"getValue": "."},
-                ]
-            }
-        },
-        [11, 12],
-    ),
-    (
-        "Iterate over a list defined in the yaml file and sum 1 to each",
-        [{
-            "containers": [
-                {"maxCPU": 1},
-                {"maxCPU": 2}
-            ]
-        }],
-        {
-            "elements": {"getValue": ".containers"},
-            "op": {
-                "sum": [
-                    {"const": 1},
-                    {"getValue": ".maxCPU"},
-                ]
-            }
-        },
-        [2, 3],
-    ),
-])
+@pytest.mark.parametrize(
+    ("name", "contexts", "inputs", "expected_result"),
+    [
+        (
+            "Iterate over a constant list of elements and sum 10 to each",
+            [],
+            {
+                "elements": {
+                    "const": [
+                        1,
+                        2,
+                    ]
+                },
+                "op": {
+                    "sum": [
+                        {"const": 10},
+                        {"getValue": "."},
+                    ]
+                },
+            },
+            [11, 12],
+        ),
+        (
+            "Iterate over a list defined in the yaml file and sum 1 to each",
+            [{"containers": [{"maxCPU": 1}, {"maxCPU": 2}]}],
+            {
+                "elements": {"getValue": ".containers"},
+                "op": {
+                    "sum": [
+                        {"const": 1},
+                        {"getValue": ".maxCPU"},
+                    ]
+                },
+            },
+            [2, 3],
+        ),
+    ],
+)
 def test_foreach(name, contexts, inputs, expected_result):
     op = cfg_parser.parse_operator({"forEach": inputs})
     result = op.get_value(contexts)
     assert result == expected_result
 
 
-@pytest.mark.parametrize(("name", "contexts", "inputs", "expected_result"), [
-    (
-        "The list contains the element",
-        [{
-            "containers": [
-                {"maxCPU": 1},
-                {"maxCPU": 2}
-            ]
-        }],
-        {
-            "elements": {"getValue": ".containers"},
-            "value": {
-                "const": {"maxCPU": 2}
-            }
-        },
-        True,
-    ),
-    (
-        "The list doesn't contain the element",
-        [{
-            "containers": [
-                {"maxCPU": 1},
-                {"maxCPU": 2}
-            ]
-        }],
-        {
-            "elements": {"getValue": ".containers"},
-            "value": {
-                "const": {"maxCPU": 4}
-            }
-        },
-        False,
-    ),
-])
+@pytest.mark.parametrize(
+    ("name", "contexts", "inputs", "expected_result"),
+    [
+        (
+            "The list contains the element",
+            [{"containers": [{"maxCPU": 1}, {"maxCPU": 2}]}],
+            {"elements": {"getValue": ".containers"}, "value": {"const": {"maxCPU": 2}}},
+            True,
+        ),
+        (
+            "The list doesn't contain the element",
+            [{"containers": [{"maxCPU": 1}, {"maxCPU": 2}]}],
+            {"elements": {"getValue": ".containers"}, "value": {"const": {"maxCPU": 4}}},
+            False,
+        ),
+    ],
+)
 def test_contain(name, contexts, inputs, expected_result):
     op = cfg_parser.parse_operator({"contain": inputs})
     result = op.get_value(contexts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 import copy
 import os
-import requests
 import socket
 import time
 from typing import Any
+
+import requests
 import yaml
 
 


### PR DESCRIPTION
This helps having the same code style in both the app and in the tests. However, we are not enforcing pylint on the tests.