### PR TITLE
Ability to modify smartly the jsonpatch based on the main json

### DIFF
--- a/generic_k8s_webhook/config_parser.py
+++ b/generic_k8s_webhook/config_parser.py
@@ -3,7 +3,7 @@ import copy
 import inspect
 import sys
 
-from generic_k8s_webhook import operators, utils
+from generic_k8s_webhook import jsonpatch_helpers, operators, utils
 from generic_k8s_webhook.webhook import Action, Webhook
 
 
@@ -78,7 +78,9 @@ class ActionParser:
         raw_condition = raw_config.pop("condition", {"const": True})
         condition = parse_operator(raw_condition, f"{path_action}.condition")
 
-        patch = raw_config.pop("patch", None)
+        raw_patch = raw_config.pop("patch", [])
+        patch = JsonPatchParser.parse(raw_patch)
+
         # By default, we always accept the payload
         accept = raw_config.pop("accept", True)
 
@@ -86,6 +88,53 @@ class ActionParser:
             raise ValueError(f"Invalid fields in action {path_action}: {raw_config}")
 
         return Action(condition, patch, accept)
+
+
+class JsonPatchParser:
+    @classmethod
+    def parse(cls, raw_patch: list) -> list[jsonpatch_helpers.JsonPatchOperator]:
+        patch = []
+        for raw_elem in raw_patch:
+            op = utils.must_pop(raw_elem, "op", f"Missing key 'op' in {raw_elem}")
+            if op == "add":
+                path = cls._parse_path(raw_elem, "path")
+                value = utils.must_pop(raw_elem, "value", f"Missing key 'value' in {raw_elem}")
+                parsed_elem = jsonpatch_helpers.JsonPatchAdd(path, value)
+            elif op == "remove":
+                path = cls._parse_path(raw_elem, "path")
+                parsed_elem = jsonpatch_helpers.JsonPatchRemove(path)
+            elif op == "replace":
+                path = cls._parse_path(raw_elem, "path")
+                value = utils.must_pop(raw_elem, "value", f"Missing key 'value' in {raw_elem}")
+                parsed_elem = jsonpatch_helpers.JsonPatchReplace(path, value)
+            elif op == "copy":
+                path = cls._parse_path(raw_elem, "path")
+                fromm = cls._parse_path(raw_elem, "from")
+                parsed_elem = jsonpatch_helpers.JsonPatchCopy(path, fromm)
+            elif op == "move":
+                path = cls._parse_path(raw_elem, "path")
+                fromm = cls._parse_path(raw_elem, "from")
+                parsed_elem = jsonpatch_helpers.JsonPatchMove(path, fromm)
+            elif op == "test":
+                path = cls._parse_path(raw_elem, "path")
+                value = utils.must_pop(raw_elem, "value", f"Missing key 'value' in {raw_elem}")
+                parsed_elem = jsonpatch_helpers.JsonPatchTest(path, value)
+            else:
+                raise ValueError(f"Invalid patch operation {raw_elem['op']}")
+
+            if len(raw_elem) > 0:
+                raise ValueError(f"Unexpected keys {raw_elem}")
+            patch.append(parsed_elem)
+
+        return patch
+
+    @classmethod
+    def _parse_path(cls, raw_elem: dict, key: str) -> list[str]:
+        raw_path = utils.must_pop(raw_elem, key, f"Missing key {key} in {raw_elem}")
+        path = utils.convert_dot_string_path_to_list(raw_path)
+        if path[0] != "":
+            raise ValueError(f"The first element of a path in the patch must be '.', not {path[0]}")
+        return path[1:]
 
 
 class OperatorParser(abc.ABC):

--- a/generic_k8s_webhook/jsonpatch_helpers.py
+++ b/generic_k8s_webhook/jsonpatch_helpers.py
@@ -1,0 +1,136 @@
+import abc
+from typing import Any
+
+import jsonpatch
+
+from generic_k8s_webhook.utils import to_number
+
+
+class JsonPatchOperator(abc.ABC):
+    def __init__(self, path: list[str]) -> None:
+        self.path = path
+
+    @abc.abstractmethod
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        pass
+
+
+class JsonPatchAdd(JsonPatchOperator):
+    def __init__(self, path: list[str], value: Any) -> None:
+        super().__init__(path)
+        self.value = value
+
+    # Remember the op "add" is like an assignment
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        # Check how many (nested) keys already exist
+        existing_path = []
+        first_non_existing_key = None
+        for key in self.path:
+            if isinstance(json_to_patch, dict):
+                if key not in json_to_patch:
+                    first_non_existing_key = key
+                    break
+                json_to_patch = json_to_patch[key]
+
+            elif isinstance(json_to_patch, list):
+                # This special case happens when we want to add an element to an existing list
+                # path: /key1/key2/-
+                if key == "-":
+                    existing_path.append(key)
+                    break
+
+                idx = to_number(key)
+                if idx > len(json_to_patch):
+                    first_non_existing_key = idx
+                    break
+                json_to_patch = json_to_patch[idx]
+
+            else:
+                raise RuntimeError(f"Expecting dict or list, but got {json_to_patch}")
+
+            existing_path.append(key)
+
+        # We can only have one non-existing key in the "path"
+        # The other ones must wrap the "value"
+        new_path = existing_path
+        new_value = self.value
+
+        if first_non_existing_key is not None:
+            # The first non-existing key must go to the "path"
+            new_path += [first_non_existing_key]
+            # The rest of non-existing keys must be part of the "values"
+            items_to_create = self.path[len(new_path) :]
+            for key in reversed(items_to_create):
+                if key == "-":
+                    new_value = [new_value]
+                else:
+                    new_value = {key: new_value}
+
+        # Convert the list to a string separated by "/"
+        formatted_path = "/" + "/".join(new_path)
+
+        return jsonpatch.JsonPatch(
+            [
+                {
+                    "op": "add",
+                    "path": formatted_path,
+                    "value": new_value,
+                }
+            ]
+        )
+
+
+class JsonPatchRemove(JsonPatchOperator):
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        # TODO If the key to remove doesn't exist, this must become a no-op
+        formatted_path = "/" + "/".join(self.path)
+        return jsonpatch.JsonPatch(
+            [
+                {
+                    "op": "remove",
+                    "path": formatted_path,
+                }
+            ]
+        )
+
+
+class JsonPatchReplace(JsonPatchOperator):
+    def __init__(self, path: list[str], value: Any) -> None:
+        super().__init__(path)
+        self.value = value
+
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        formatted_path = "/" + "/".join(self.path)
+        return jsonpatch.JsonPatch([{"op": "replace", "path": formatted_path, "value": self.value}])
+
+
+class JsonPatchCopy(JsonPatchOperator):
+    def __init__(self, path: list[str], fromm: Any) -> None:
+        super().__init__(path)
+        self.fromm = fromm
+
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        formatted_path = "/" + "/".join(self.path)
+        formatted_from = "/" + "/".join(self.fromm)
+        return jsonpatch.JsonPatch([{"op": "copy", "path": formatted_path, "from": formatted_from}])
+
+
+class JsonPatchMove(JsonPatchOperator):
+    def __init__(self, path: list[str], fromm: Any) -> None:
+        super().__init__(path)
+        self.fromm = fromm
+
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        formatted_path = "/" + "/".join(self.path)
+        formatted_from = "/" + "/".join(self.fromm)
+        return jsonpatch.JsonPatch([{"op": "move", "path": formatted_path, "from": formatted_from}])
+
+
+class JsonPatchTest(JsonPatchOperator):
+    def __init__(self, path: list[str], value: Any) -> None:
+        super().__init__(path)
+        self.value = value
+
+    def generate_patch(self, json_to_patch: dict | list) -> jsonpatch.JsonPatch:
+        formatted_path = "/" + "/".join(self.path)
+        return jsonpatch.JsonPatch([{"op": "test", "path": formatted_path, "value": self.value}])

--- a/generic_k8s_webhook/operators.py
+++ b/generic_k8s_webhook/operators.py
@@ -2,22 +2,10 @@ import abc
 from numbers import Number
 from typing import Any, Union, get_args, get_origin
 
-
-def _to_number(element) -> int | float:
-    try:
-        return int(element)
-    except (ValueError, TypeError):
-        pass
-    try:
-        return float(element)
-    except (ValueError, TypeError):
-        pass
-
-    raise RuntimeError(f"Cannot convert {element} to number")
-
+from generic_k8s_webhook.utils import to_number
 
 # Make Number callable, so it can convert, for example, a string into an int or float
-Number.__call__ = _to_number
+Number.__call__ = to_number
 
 
 class Operator(abc.ABC):

--- a/generic_k8s_webhook/utils.py
+++ b/generic_k8s_webhook/utils.py
@@ -20,3 +20,16 @@ def convert_dot_string_path_to_list(dot_string_path: str) -> list[str]:
     # Convert the '\.' to '.'
     path = [elem.replace("\\.", ".") for elem in path]
     return path
+
+
+def to_number(element) -> int | float:
+    try:
+        return int(element)
+    except (ValueError, TypeError):
+        pass
+    try:
+        return float(element)
+    except (ValueError, TypeError):
+        pass
+
+    raise RuntimeError(f"Cannot convert {element} to number")

--- a/generic_k8s_webhook/webhook.py
+++ b/generic_k8s_webhook/webhook.py
@@ -2,31 +2,34 @@ import copy
 
 import jsonpatch
 
+from generic_k8s_webhook.jsonpatch_helpers import JsonPatchOperator
 from generic_k8s_webhook.operators import Operator
 from generic_k8s_webhook.utils import convert_dot_string_path_to_list
 
 
 class Action:
-    def __init__(self, condition: Operator, patch: list[dict], accept: bool) -> None:
+    def __init__(self, condition: Operator, list_jpatch_op: list[JsonPatchOperator], accept: bool) -> None:
         self.condition = condition
-        self.patch = patch
+        self.list_jpatch_op = list_jpatch_op
         self.accept = accept
 
     def check_condition(self, manifest: dict) -> bool:
         return self.condition.get_value([manifest])
 
     def get_patches(self, manifest: dict) -> jsonpatch.JsonPatch | None:
-        if not self.patch:
+        if not self.list_jpatch_op:
             return None
 
-        # TODO This needs much better robustness and error handling
-        formatted_patch = copy.deepcopy(self.patch)
-        for operation in formatted_patch:
-            for key in ["path", "from"]:
-                if key in operation:
-                    path_list = convert_dot_string_path_to_list(operation[key])
-                    operation[key] = "/" + "/".join(path_list[1:])
-        return jsonpatch.JsonPatch(formatted_patch)
+        # 1. Generate a json patch specific for the manifest
+        # 2. Update the manifest based on that patch
+        # 3. Extract the raw patch, so we can merge later all the patches into a single JsonPatch object
+        list_raw_patches = []
+        for jpatch_op in self.list_jpatch_op:
+            jpatch = jpatch_op.generate_patch(manifest)
+            manifest = jpatch.apply(manifest)
+            list_raw_patches.extend(jpatch.patch)
+
+        return jsonpatch.JsonPatch(list_raw_patches)
 
 
 class Webhook:

--- a/tests/http_server_test_data/test_case_3.yaml
+++ b/tests/http_server_test_data/test_case_3.yaml
@@ -70,7 +70,7 @@ webhook_config:
 
           patch:
             - op: add
-              path: .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution
+              path: .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.-
               value:
                 preference:
                   matchExpressions:
@@ -128,7 +128,7 @@ cases:
         patchType: JSONPatch
         patch:
           - op: add
-            path: /spec/affinity/nodeAffinity/preferredDuringSchedulingIgnoredDuringExecution
+            path: /spec/affinity/nodeAffinity/preferredDuringSchedulingIgnoredDuringExecution/-
             value:
               preference:
                 matchExpressions:
@@ -137,3 +137,34 @@ cases:
                     values:
                       - cheap
               weight: 1
+
+  - patches:
+      - key:
+          [
+            request,
+            body,
+            request,
+            object,
+            spec,
+            affinity,
+          ]
+        value: {}
+    expected_response:
+      apiVersion: admission.k8s.io/v1
+      kind: AdmissionReview
+      response:
+        uid: "4321"
+        allowed: True
+        patchType: JSONPatch
+        patch:
+          - op: add
+            path: /spec/affinity/nodeAffinity
+            value:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: myorg.io/instance-cost
+                        operator: In
+                        values:
+                          - cheap
+                  weight: 1

--- a/tests/jsonpatch_helpers_test.py
+++ b/tests/jsonpatch_helpers_test.py
@@ -1,0 +1,167 @@
+import pytest
+
+from generic_k8s_webhook.config_parser import JsonPatchParser
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Change the value of a simple key",
+            {"spec": {}, "metadata": {}},
+            [{"op": "add", "path": ".spec", "value": "foo"}],
+            {"spec": "foo", "metadata": {}},
+        ),
+        (
+            "Add a subkey that doesn't exist",
+            {"spec": {}, "metadata": {}},
+            [{"op": "add", "path": ".spec.subkey", "value": "foo"}],
+            {"spec": {"subkey": "foo"}, "metadata": {}},
+        ),
+        (
+            "Add a 2 subkeys that don't exist",
+            {"spec": {}, "metadata": {}},
+            [{"op": "add", "path": ".spec.subkey1.subkey2", "value": "foo"}],
+            {"spec": {"subkey1": {"subkey2": "foo"}}, "metadata": {}},
+        ),
+        (
+            "Add an element to an existing empty list",
+            {"spec": {"containers": []}, "metadata": {}},
+            [{"op": "add", "path": ".spec.containers.-", "value": {"name": "main"}}],
+            {"spec": {"containers": [{"name": "main"}]}, "metadata": {}},
+        ),
+        (
+            "Add an element to an existing non-empty list",
+            {"spec": {"containers": [{"name": "sidecar"}]}, "metadata": {}},
+            [{"op": "add", "path": ".spec.containers.-", "value": {"name": "main"}}],
+            {"spec": {"containers": [{"name": "sidecar"}, {"name": "main"}]}, "metadata": {}},
+        ),
+        (
+            "Add an element to a non-existing list",
+            {"spec": {}, "metadata": {}},
+            [{"op": "add", "path": ".spec.containers.-", "value": {"name": "main"}}],
+            {"spec": {"containers": [{"name": "main"}]}, "metadata": {}},
+        ),
+        (
+            "Add a new entry on the second element of the list",
+            {"spec": {"containers": [{"name": "main"}]}, "metadata": {}},
+            [{"op": "add", "path": ".spec.containers.0.metadata", "value": {}}],
+            {"spec": {"containers": [{"name": "main", "metadata": {}}]}, "metadata": {}},
+        ),
+    ],
+)
+def test_add(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "add" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Remove the value of a simple key",
+            {"spec": {}, "metadata": {}},
+            [
+                {
+                    "op": "remove",
+                    "path": ".spec",
+                }
+            ],
+            {"metadata": {}},
+        ),
+        # (
+        #     "Remove a key that doesn't exist",
+        #     {"spec": {}, "metadata": {}},
+        #     [{
+        #         "op": "remove",
+        #         "path": ".status",
+        #     }],
+        #     {"spec": {}, "metadata": {}}
+        # ),
+    ],
+)
+def test_remove(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "remove" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Replace the value of a simple key",
+            {"spec": {}, "metadata": {"name": "foo"}},
+            [{"op": "replace", "path": ".metadata.name", "value": "bar"}],
+            {"spec": {}, "metadata": {"name": "bar"}},
+        ),
+    ],
+)
+def test_replace(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "replace" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Copy the value from a simple key to another",
+            {"spec": {"containers": [{"name": "bar"}]}, "metadata": {"name": "foo"}},
+            [{"op": "copy", "path": ".metadata.name", "from": ".spec.containers.0.name"}],
+            {"spec": {"containers": [{"name": "bar"}]}, "metadata": {"name": "bar"}},
+        ),
+    ],
+)
+def test_copy(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "copy" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Move the value from a simple key to another",
+            {"spec": {"containers": [{"name": "bar"}]}, "metadata": {"name": "foo"}},
+            [{"op": "move", "path": ".metadata.name", "from": ".spec.containers.0.name"}],
+            {"spec": {"containers": [{}]}, "metadata": {"name": "bar"}},
+        ),
+    ],
+)
+def test_move(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "move" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result
+
+
+@pytest.mark.parametrize(
+    ("name", "json_to_patch", "patch", "expected_result"),
+    [
+        (
+            "Test the value of a simple key",
+            {"spec": {}, "metadata": {"name": "foo"}},
+            [{"op": "test", "path": ".metadata.name", "value": "foo"}],
+            {"spec": {}, "metadata": {"name": "foo"}},
+        ),
+    ],
+)
+def test_test(name, json_to_patch, patch, expected_result):
+    assert all(elem["op"] == "test" for elem in patch)
+    patcher = JsonPatchParser.parse(patch)[0]
+    processed_patch = patcher.generate_patch(json_to_patch)
+    patched_json = processed_patch.apply(json_to_patch)
+    assert patched_json == expected_result

--- a/tests/webhook_configs/config1.yaml
+++ b/tests/webhook_configs/config1.yaml
@@ -10,7 +10,7 @@ webhooks:
             - getValue: .metadata.name
             - const: my-app
         patch:
-          op: replace
-          path: .metadata.name
-          value: my-awesome-app
+          - op: replace
+            path: .metadata.name
+            value: my-awesome-app
         accept: true


### PR DESCRIPTION
One of the limitations of jsonpatch is that, for example, if we add a new value, the path of subkeys where this value live must exist. If these subkeys don't exist, then the add operation fail.

This commit adds a step to parse a raw patch and wrappers over each patch operation. The important feature is that, when we find non-existing subkeys in the add operation, then we push these keys into the value that we are adding, so they get created.