### PR TITLE
Inject git tag in the pyproject.toml file as the package version

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
+      - name: Write version
+        run: ./scripts/insert-version-pyproject.sh ${{github.ref_name}}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check pyproject.toml
+        run: ./scripts/check-pyproject.sh
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "generic_k8s_webhook"
-version = "0.1.0"
+# This is substituted in the publish-artifacts pipeline by the current git tag
+version = "0.0.0"
 description = "Configurable webhook that can implement multiple validators and mutators using a simple yaml config file"
 authors = ["jordi <jordipiqueselles@gmail.com>"]
 license = "Apache License"

--- a/scripts/check-pyproject.sh
+++ b/scripts/check-pyproject.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+REPOROOT_PATH="$SCRIPTPATH/.."
+
+echo "Check the $REPOROOT_PATH/pyproject.toml has 'version = \"0.0.0\"'"
+grep 'version = "0.0.0"' pyproject.toml

--- a/scripts/insert-version-pyproject.sh
+++ b/scripts/insert-version-pyproject.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+REPOROOT_PATH="$SCRIPTPATH/.."
+
+NEW_VERSION=$1
+
+sed -i "s/version = \"0.0.0\"/version = \"$NEW_VERSION\"/g" "$REPOROOT_PATH/pyproject.toml"

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -6,6 +6,7 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 
 cd "$SCRIPTPATH/.."
+./scripts/check-pyproject.sh
 echo "Running linter"
 ./scripts/format-code.sh --check
 echo "Running unittests and e2e tests"


### PR DESCRIPTION
This helps us having a single source of truth for the versions, which is the git tag. This git tag is inserted to the pyproject.toml file, in the version field, as part of the job that builds and pushes the docker image when a new release is created.